### PR TITLE
changed $currentMembers to $currentGroupMembers

### DIFF
--- a/permissions/groups/grantPermission.ps1
+++ b/permissions/groups/grantPermission.ps1
@@ -174,8 +174,8 @@ try {
             $actionMessage = "granting permission"
 
             $memberToAdd = @{value = $actionContext.References.Account }
-            $currentMembers += $memberToAdd
-            [array]$updatedMembers = $currentMembers
+            $currentGroupMembers += $memberToAdd
+            [array]$updatedMembers = $currentGroupMembers
 
             # Force object to an Array also if PS object only has one value.
             $updatedMembersJSON = ConvertTo-Json -InputObject @($updatedMembers)


### PR DESCRIPTION
changed $currentMembers to $currentGroupMembers.

The current members are retrieved in the variable $currentGroupMembers, but a new employee was added to $currentMembers. As a result, we don't always send the complete set of users to Zivver. This has now been adjusted and tested at the customer.